### PR TITLE
Fix to enforceLog4J2 methods. 

### DIFF
--- a/src/main/java/dev/jacomet/gradle/plugins/logging/extension/LoggingCapabilitiesExtension.java
+++ b/src/main/java/dev/jacomet/gradle/plugins/logging/extension/LoggingCapabilitiesExtension.java
@@ -341,10 +341,7 @@ public class LoggingCapabilitiesExtension {
      */
     public void enforceLog4J2() {
         selectSlf4JLog4J2Interaction(LoggingModuleIdentifiers.LOG4J_SLF4J_IMPL.asVersionZero());
-        selectJulDelegation(LoggingModuleIdentifiers.LOG4J_JUL.asVersionZero());
-        selectJCLImplementation(LoggingModuleIdentifiers.LOG4J_JCL.asVersionZero());
-        selectLog4J12Implementation(LoggingModuleIdentifiers.LOG4J12API.asVersionZero());
-
+        enforceSlf4JImplementation();
     }
 
     /**
@@ -357,10 +354,7 @@ public class LoggingCapabilitiesExtension {
      */
     public void enforceLog4J2(String configurationName) {
         selectSlf4JLog4J2Interaction(configurationName, LoggingModuleIdentifiers.LOG4J_SLF4J_IMPL.asVersionZero());
-        selectJulDelegation(configurationName, LoggingModuleIdentifiers.LOG4J_JUL.asVersionZero());
-        selectJCLImplementation(configurationName, LoggingModuleIdentifiers.LOG4J_JCL.asVersionZero());
-        selectLog4J12Implementation(configurationName, LoggingModuleIdentifiers.LOG4J12API.asVersionZero());
-
+        enforceSlf4JImplementation(configurationName);
     }
 
     /**


### PR DESCRIPTION
Should be enforcing Slf4JImplementation but instead selects logging implementations other than Log4J2.

Note:
- I haven't tested the fix
- I have verified that when enforcing Log4J2 as the logging implementation, other logging frameworks still exist (if in dependencies). Expected behaviour: the other logging frameworks get replaced with their equivalent SLF4J bridges