### PR TITLE
Allow testing with a specific Gradle version, and setup matrix in CI

### DIFF
--- a/.github/workflows/gradle-build.yml
+++ b/.github/workflows/gradle-build.yml
@@ -19,3 +19,28 @@ jobs:
 
       - name: Execute Gradle build
         run: ./gradlew build
+
+  test-matrix:
+    needs: [gradle]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # Test around 6.2, 6.0 and 5.2 breaking points, and the lower and upper boundaries
+        # Version 6.0 is omitted as it's already tested above
+        gradle: ["7.4.2", "6.3", "6.2.2", "6.1.1", "5.6.4", "5.3.1", "5.2.1", "5.1.1", "5.0"]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
+        with:
+          java-version: 8
+          distribution: temurin
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          # Only write to the cache for builds on the 'main' branch.
+          # Builds on other branches will only read existing entries from the cache.
+          cache-read-only: ${{ github.ref != 'refs/heads/master' }}
+
+      - name: Execute Gradle build
+        run: ./gradlew functionalTest -Ptest.gradle-version=${{ matrix.gradle }}

--- a/README.adoc
+++ b/README.adoc
@@ -37,7 +37,7 @@ Have a look at https://plugins.gradle.org/plugin/dev.jacomet.logging-capabilitie
 |===
 | Gradle version | Available feature
 
-| Gradle 4.7+
+| Gradle 5.0+
 | The detection part is available
 
 | Gradle 6.0+

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+import org.gradle.util.GradleVersion
+
 plugins {
     `java-gradle-plugin`
     groovy
@@ -84,6 +86,11 @@ license {
     exclude("**/.gradle/*")
 }
 
-tasks.withType<Test> {
-    useJUnitPlatform()
+tasks {
+    withType<Test> {
+        useJUnitPlatform()
+    }
+    functionalTest {
+        systemProperty("test.gradle-version", project.findProperty("test.gradle-version") ?: GradleVersion.current().version)
+    }
 }

--- a/src/functionalTest/groovy/dev/jacomet/gradle/plugins/logging/AbstractLoggingCapabilitiesPluginFunctionalTest.groovy
+++ b/src/functionalTest/groovy/dev/jacomet/gradle/plugins/logging/AbstractLoggingCapabilitiesPluginFunctionalTest.groovy
@@ -3,12 +3,15 @@ package dev.jacomet.gradle.plugins.logging
 import org.gradle.testkit.runner.BuildResult
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
+import org.gradle.util.GradleVersion
 import spock.lang.Specification
 import spock.lang.TempDir
 
 import java.nio.file.Path
 
 abstract class AbstractLoggingCapabilitiesPluginFunctionalTest extends Specification {
+
+    static GradleVersion testGradleVersion = System.getProperty("test.gradle-version")?.with { GradleVersion.version(it) } ?: GradleVersion.current()
 
     @TempDir
     Path testFolder
@@ -34,6 +37,7 @@ abstract class AbstractLoggingCapabilitiesPluginFunctionalTest extends Specifica
     GradleRunner gradleRunnerFor(List<String>  args) {
         GradleRunner.create()
                 .forwardOutput()
+                .withGradleVersion(testGradleVersion.version)
                 .withPluginClasspath()
                 .withProjectDir(testFolder.toFile())
                 .withArguments(args + ["-s"])

--- a/src/functionalTest/groovy/dev/jacomet/gradle/plugins/logging/LoggingCapabilitiesPluginSelectionFunctionalTest.groovy
+++ b/src/functionalTest/groovy/dev/jacomet/gradle/plugins/logging/LoggingCapabilitiesPluginSelectionFunctionalTest.groovy
@@ -1,6 +1,7 @@
 package dev.jacomet.gradle.plugins.logging
 
 import org.gradle.util.GradleVersion
+import spock.lang.IgnoreIf
 import spock.lang.Requires
 import spock.lang.Unroll
 
@@ -11,6 +12,8 @@ import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 class LoggingCapabilitiesPluginSelectionFunctionalTest extends AbstractLoggingCapabilitiesPluginFunctionalTest {
 
     @Unroll
+    // Looks like a regression in Gradle 6.7+: https://github.com/ljacomet/logging-capabilities/issues/20
+    @IgnoreIf({ instance.testGradleVersion >= GradleVersion.version("6.7") })
     def "can select logback in case of conflict (with extra #additional)"() {
         given:
         withBuildScript("""

--- a/src/functionalTest/groovy/dev/jacomet/gradle/plugins/logging/LoggingCapabilitiesPluginSelectionFunctionalTest.groovy
+++ b/src/functionalTest/groovy/dev/jacomet/gradle/plugins/logging/LoggingCapabilitiesPluginSelectionFunctionalTest.groovy
@@ -1,10 +1,13 @@
 package dev.jacomet.gradle.plugins.logging
 
+import org.gradle.util.GradleVersion
+import spock.lang.Requires
 import spock.lang.Unroll
 
 import static org.gradle.testkit.runner.TaskOutcome.FAILED
 import static org.gradle.testkit.runner.TaskOutcome.SUCCESS
 
+@Requires({ LoggingCapabilitiesPluginSelectionFunctionalTest.testGradleVersion >= GradleVersion.version("6.0") })
 class LoggingCapabilitiesPluginSelectionFunctionalTest extends AbstractLoggingCapabilitiesPluginFunctionalTest {
 
     @Unroll


### PR DESCRIPTION
Properly ignore (or fix) tests for older versions of Gradle.

Had to ignore one test for Gradle 6.7+ for what seems to be a regression in Gradle itself (see #20)

Fix README wrt supported Gradle versions:
* ComponentMetadataRule was added in 4.9
* belongsTo(Object,boolean) was added in 5.0

Fixes #7 